### PR TITLE
fix(helm): remove duplicated metadata in leader election role

### DIFF
--- a/helm/postgresql-operator/templates/leader_election_role.yaml
+++ b/helm/postgresql-operator/templates/leader_election_role.yaml
@@ -2,7 +2,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-metadata:
   name: {{ include "postgresql-operator.fullname" . }}-leader-election-role
   labels:
 {{ include "postgresql-operator.labels" . | indent 4 }}


### PR DESCRIPTION
Remove duplicate metadata field in leader election role.
It causes our ArgoCD to complain about missing metadata.name.